### PR TITLE
Issue #10 - Add network interface selection

### DIFF
--- a/app/src/main/java/com/networkscanner/app/data/ScanResult.kt
+++ b/app/src/main/java/com/networkscanner/app/data/ScanResult.kt
@@ -36,6 +36,7 @@ data class ScanResult(
  * Network information for the current connection.
  */
 data class NetworkInfo(
+    val interfaceName: String? = null,
     val ssid: String?,
     val bssid: String?,
     val ipAddress: String,

--- a/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
+++ b/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
@@ -80,16 +80,17 @@ class NetworkScanner(private val context: Context) {
     /**
      * Start a full network scan.
      */
-    suspend fun scan(): ScanResult = withContext(scope.coroutineContext) {
+    suspend fun scan(interfaceName: String? = null): ScanResult = withContext(scope.coroutineContext) {
         val startTime = Date()
         discoveredDevices.clear()
 
-        val networkInfo = NetworkUtils.getNetworkInfo(context)
+        val networkInfo = NetworkUtils.getNetworkInfo(context, interfaceName)
             ?: return@withContext ScanResult(
                 devices = emptyList(),
                 scanStartTime = startTime,
                 scanEndTime = Date(),
                 networkInfo = NetworkInfo(
+                    interfaceName = interfaceName,
                     ssid = null,
                     bssid = null,
                     ipAddress = "0.0.0.0",
@@ -98,7 +99,7 @@ class NetworkScanner(private val context: Context) {
                     networkPrefix = 24
                 ),
                 scanStatus = ScanStatus.ERROR,
-                error = "No WiFi connection"
+                error = "No active network interface"
             )
 
         // Add current device
@@ -628,7 +629,7 @@ class NetworkScanner(private val context: Context) {
 
     private fun addCurrentDevice(networkInfo: NetworkInfo) {
         val localIp = networkInfo.ipAddress
-        val localMac = NetworkUtils.getLocalMacAddress()
+        val localMac = NetworkUtils.getLocalMacAddress(networkInfo.interfaceName)
         val vendor = MacVendorLookup.lookup(localMac)
 
         val currentDevice = Device(

--- a/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.networkscanner.app.NetworkScannerApp
 import com.networkscanner.app.data.*
+import com.networkscanner.app.util.NetworkInterfaceOption
 import com.networkscanner.app.util.NetworkUtils
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +40,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _networkInfo = MutableStateFlow<NetworkInfo?>(null)
     val networkInfo: StateFlow<NetworkInfo?> = _networkInfo.asStateFlow()
 
+    private val _availableInterfaces = MutableStateFlow<List<NetworkInterfaceOption>>(emptyList())
+    val availableInterfaces: StateFlow<List<NetworkInterfaceOption>> = _availableInterfaces.asStateFlow()
+
+    private val _selectedInterfaceName = MutableStateFlow<String?>(null)
+    val selectedInterfaceName: StateFlow<String?> = _selectedInterfaceName.asStateFlow()
+
     private val _errorMessage = Channel<String>(Channel.BUFFERED)
     val errorMessage = _errorMessage.receiveAsFlow()
 
@@ -54,13 +61,31 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 _scanProgress.value = progress
             }
         }
+
+        refreshInterfaces()
     }
 
     /**
-     * Check if WiFi is connected.
+     * Refresh active network interfaces and keep selection valid.
      */
-    fun isWifiConnected(): Boolean {
-        return NetworkUtils.isWifiConnected(getApplication())
+    fun refreshInterfaces() {
+        val interfaces = NetworkUtils.getAvailableInterfaces()
+        _availableInterfaces.value = interfaces
+
+        val current = _selectedInterfaceName.value
+        _selectedInterfaceName.value = when {
+            interfaces.isEmpty() -> null
+            current != null && interfaces.any { it.name == current } -> current
+            else -> interfaces.first().name
+        }
+    }
+
+    fun onInterfaceSelected(interfaceName: String) {
+        _selectedInterfaceName.value = interfaceName
+
+        // Update header info immediately for the selected interface, then auto-scan.
+        _networkInfo.value = NetworkUtils.getNetworkInfo(getApplication(), interfaceName)
+        startScan()
     }
 
     /**
@@ -70,7 +95,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (_uiState.value is UiState.Scanning) return
 
         viewModelScope.launch {
-            if (!isWifiConnected()) {
+            refreshInterfaces()
+            val interfaceName = _selectedInterfaceName.value
+            if (interfaceName == null) {
                 _uiState.value = UiState.NoWifi
                 return@launch
             }
@@ -78,7 +105,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             _uiState.value = UiState.Scanning
 
             try {
-                val result = scanner.scan()
+                val result = scanner.scan(interfaceName)
 
                 _networkInfo.value = result.networkInfo
                 updateDeviceLists(result.devices)

--- a/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
@@ -78,14 +78,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             current != null && interfaces.any { it.name == current } -> current
             else -> interfaces.first().name
         }
+
+        _networkInfo.value = _networkInfo.value
+            ?: NetworkUtils.getNetworkInfo(getApplication(), _selectedInterfaceName.value)
     }
 
     fun onInterfaceSelected(interfaceName: String) {
         _selectedInterfaceName.value = interfaceName
-
-        // Update header info immediately for the selected interface, then auto-scan.
         _networkInfo.value = NetworkUtils.getNetworkInfo(getApplication(), interfaceName)
-        startScan()
     }
 
     /**

--- a/app/src/main/java/com/networkscanner/app/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/screens/home/HomeScreen.kt
@@ -55,6 +55,8 @@ fun HomeScreen(
     val offlineDevices by viewModel.offlineDevices.collectAsState()
     val scanProgress by viewModel.scanProgress.collectAsState()
     val networkInfo by viewModel.networkInfo.collectAsState()
+    val availableInterfaces by viewModel.availableInterfaces.collectAsState()
+    val selectedInterfaceName by viewModel.selectedInterfaceName.collectAsState()
 
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
@@ -69,6 +71,8 @@ fun HomeScreen(
     }
 
     LaunchedEffect(Unit) {
+        viewModel.refreshInterfaces()
+
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val autoScan = prefs.getBoolean("auto_scan_on_start", true)
         if (autoScan && uiState is MainViewModel.UiState.Idle) {
@@ -118,7 +122,13 @@ fun HomeScreen(
                 .padding(innerPadding)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                NetworkInfoBar(networkInfo = networkInfo)
+                NetworkInfoBar(
+                    networkInfo = networkInfo,
+                    interfaces = availableInterfaces,
+                    selectedInterfaceName = selectedInterfaceName,
+                    onInterfaceSelected = viewModel::onInterfaceSelected,
+                    isScanning = isScanning
+                )
 
                 AnimatedContent(
                     targetState = uiState,

--- a/app/src/main/java/com/networkscanner/app/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/screens/home/HomeScreen.kt
@@ -71,8 +71,6 @@ fun HomeScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.refreshInterfaces()
-
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val autoScan = prefs.getBoolean("auto_scan_on_start", true)
         if (autoScan && uiState is MainViewModel.UiState.Idle) {

--- a/app/src/main/java/com/networkscanner/app/ui/screens/home/NetworkInfoBar.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/screens/home/NetworkInfoBar.kt
@@ -4,19 +4,32 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.Public
+import androidx.compose.material.icons.outlined.SettingsEthernet
+import androidx.compose.material.icons.outlined.SignalCellular4Bar
+import androidx.compose.material.icons.outlined.VpnKey
 import androidx.compose.material.icons.outlined.Wifi
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -25,20 +38,49 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.networkscanner.app.R
 import com.networkscanner.app.data.NetworkInfo
+import com.networkscanner.app.util.InterfaceType
+import com.networkscanner.app.util.NetworkInterfaceOption
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NetworkInfoBar(
     networkInfo: NetworkInfo?,
+    interfaces: List<NetworkInterfaceOption>,
+    selectedInterfaceName: String?,
+    onInterfaceSelected: (String) -> Unit,
+    isScanning: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val motionScheme = MaterialTheme.motionScheme
+    if (interfaces.isEmpty() && networkInfo == null) return
 
-    // Remember the last non-null info so exit animation doesn't show stale/null data
-    val lastInfo = remember(networkInfo) { networkInfo } ?: return
+    val motionScheme = MaterialTheme.motionScheme
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    val selectedInterface = interfaces.firstOrNull { it.name == selectedInterfaceName }
+    val selectedType = selectedInterface?.type
+    val selectedNetworkInfo = networkInfo?.takeIf { it.interfaceName == selectedInterfaceName }
+
+    val selectedLabel = if (selectedInterface != null) {
+        stringResource(
+            R.string.interface_option_format,
+            interfaceTypeLabel(selectedInterface.type),
+            selectedInterface.name,
+            selectedInterface.ipAddress
+        )
+    } else {
+        stringResource(R.string.no_active_interfaces)
+    }
+
+    val interfaceIcon = when (selectedType) {
+        InterfaceType.WIFI -> Icons.Outlined.Wifi
+        InterfaceType.ETHERNET -> Icons.Outlined.SettingsEthernet
+        InterfaceType.VPN -> Icons.Outlined.VpnKey
+        InterfaceType.CELLULAR -> Icons.Outlined.SignalCellular4Bar
+        InterfaceType.OTHER, null -> Icons.Outlined.Public
+    }
 
     AnimatedVisibility(
-        visible = networkInfo != null,
+        visible = networkInfo != null || interfaces.isNotEmpty(),
         enter = expandVertically(motionScheme.defaultSpatialSpec()),
         exit = shrinkVertically(motionScheme.defaultSpatialSpec()),
         modifier = modifier
@@ -53,29 +95,103 @@ fun NetworkInfoBar(
                 contentDescription = description
             }
         ) {
-            Row(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Wifi,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = lastInfo.ssid ?: unknownNetwork,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = lastInfo.cidrNotation,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = interfaceIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            text = selectedInterface?.name
+                                ?: selectedNetworkInfo?.ssid
+                                ?: selectedType?.let { interfaceTypeLabel(it) }
+                                ?: unknownNetwork,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+
+                    Box {
+                        TextButton(
+                            enabled = !isScanning && interfaces.isNotEmpty(),
+                            onClick = { menuExpanded = true }
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = selectedLabel,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Icon(
+                                    imageVector = Icons.Outlined.ArrowDropDown,
+                                    contentDescription = stringResource(R.string.cd_interface_selector),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false }
+                        ) {
+                            interfaces.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            stringResource(
+                                                R.string.interface_option_format,
+                                                interfaceTypeLabel(option.type),
+                                                option.name,
+                                                option.ipAddress
+                                            )
+                                        )
+                                    },
+                                    onClick = {
+                                        onInterfaceSelected(option.name)
+                                        menuExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (selectedNetworkInfo != null) {
+                    Text(
+                        text = selectedNetworkInfo.cidrNotation,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }
+}
+
+@Composable
+private fun interfaceTypeLabel(type: InterfaceType): String {
+    val labelResId = when (type) {
+        InterfaceType.WIFI -> R.string.interface_type_wifi
+        InterfaceType.ETHERNET -> R.string.interface_type_ethernet
+        InterfaceType.VPN -> R.string.interface_type_vpn
+        InterfaceType.CELLULAR -> R.string.interface_type_cellular
+        InterfaceType.OTHER -> R.string.interface_type_network
+    }
+    return stringResource(labelResId)
 }

--- a/app/src/main/java/com/networkscanner/app/ui/screens/home/NetworkInfoBar.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/screens/home/NetworkInfoBar.kt
@@ -3,8 +3,8 @@ package com.networkscanner.app.ui.screens.home
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,7 +24,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.networkscanner.app.R
 import com.networkscanner.app.data.NetworkInfo
@@ -60,17 +60,6 @@ fun NetworkInfoBar(
     val selectedType = selectedInterface?.type
     val selectedNetworkInfo = networkInfo?.takeIf { it.interfaceName == selectedInterfaceName }
 
-    val selectedLabel = if (selectedInterface != null) {
-        stringResource(
-            R.string.interface_option_format,
-            interfaceTypeLabel(selectedInterface.type),
-            selectedInterface.name,
-            selectedInterface.ipAddress
-        )
-    } else {
-        stringResource(R.string.no_active_interfaces)
-    }
-
     val interfaceIcon = when (selectedType) {
         InterfaceType.WIFI -> Icons.Outlined.Wifi
         InterfaceType.ETHERNET -> Icons.Outlined.SettingsEthernet
@@ -79,105 +68,97 @@ fun NetworkInfoBar(
         InterfaceType.OTHER, null -> Icons.Outlined.Public
     }
 
+    val networkName = selectedNetworkInfo?.ssid
+        ?: selectedType?.let { interfaceTypeLabel(it) }
+        ?: stringResource(R.string.unknown_device)
+
+    val cidrText = selectedNetworkInfo?.cidrNotation
+        ?: selectedInterface?.ipAddress
+        ?: stringResource(R.string.no_active_interfaces)
+
     AnimatedVisibility(
         visible = networkInfo != null || interfaces.isNotEmpty(),
         enter = expandVertically(motionScheme.defaultSpatialSpec()),
         exit = shrinkVertically(motionScheme.defaultSpatialSpec()),
         modifier = modifier
     ) {
-        val unknownNetwork = stringResource(R.string.unknown_device)
-        val description = stringResource(
-            R.string.cd_network_info
-        )
+        val description = stringResource(R.string.cd_network_info)
         Surface(
             color = MaterialTheme.colorScheme.surfaceContainer,
-            modifier = Modifier.semantics {
-                contentDescription = description
-            }
+            modifier = Modifier.semantics { contentDescription = description }
         ) {
-            Column(
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+                Icon(
+                    imageVector = interfaceIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = networkName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Box {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = if (interfaces.size > 1 && !isScanning) {
+                            Modifier.clickable { menuExpanded = true }
+                        } else Modifier,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(
-                            imageVector = interfaceIcon,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
                         Text(
-                            text = selectedInterface?.name
-                                ?: selectedNetworkInfo?.ssid
-                                ?: selectedType?.let { interfaceTypeLabel(it) }
-                                ?: unknownNetwork,
-                            style = MaterialTheme.typography.bodyMedium
+                            text = cidrText,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1
                         )
-                    }
-
-                    Box {
-                        TextButton(
-                            enabled = !isScanning && interfaces.isNotEmpty(),
-                            onClick = { menuExpanded = true }
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = selectedLabel,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary
-                                )
-                                Icon(
-                                    imageVector = Icons.Outlined.ArrowDropDown,
-                                    contentDescription = stringResource(R.string.cd_interface_selector),
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
-                        }
-
-                        DropdownMenu(
-                            expanded = menuExpanded,
-                            onDismissRequest = { menuExpanded = false }
-                        ) {
-                            interfaces.forEach { option ->
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            stringResource(
-                                                R.string.interface_option_format,
-                                                interfaceTypeLabel(option.type),
-                                                option.name,
-                                                option.ipAddress
-                                            )
-                                        )
-                                    },
-                                    onClick = {
-                                        onInterfaceSelected(option.name)
-                                        menuExpanded = false
-                                    }
-                                )
-                            }
+                        if (interfaces.size > 1) {
+                            Icon(
+                                imageVector = Icons.Outlined.ArrowDropDown,
+                                contentDescription = stringResource(R.string.cd_interface_selector),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
                     }
-                }
-
-                if (selectedNetworkInfo != null) {
-                    Text(
-                        text = selectedNetworkInfo.cidrNotation,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false },
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                    ) {
+                        interfaces.forEach { option ->
+                            val optionIcon = when (option.type) {
+                                InterfaceType.WIFI -> Icons.Outlined.Wifi
+                                InterfaceType.ETHERNET -> Icons.Outlined.SettingsEthernet
+                                InterfaceType.VPN -> Icons.Outlined.VpnKey
+                                InterfaceType.CELLULAR -> Icons.Outlined.SignalCellular4Bar
+                                InterfaceType.OTHER -> Icons.Outlined.Public
+                            }
+                            DropdownMenuItem(
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = optionIcon,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                },
+                                text = {
+                                    Text("${interfaceTypeLabel(option.type)} — ${option.ipAddress}")
+                                },
+                                onClick = {
+                                    onInterfaceSelected(option.name)
+                                    menuExpanded = false
+                                }
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
+++ b/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
@@ -27,6 +27,20 @@ data class PingResult(
     val ttl: Int? = null
 )
 
+data class NetworkInterfaceOption(
+    val name: String,
+    val ipAddress: String,
+    val type: InterfaceType
+)
+
+enum class InterfaceType {
+    WIFI,
+    ETHERNET,
+    VPN,
+    CELLULAR,
+    OTHER
+}
+
 object NetworkUtils {
 
     private val IP_PATTERN = Regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$")
@@ -54,54 +68,69 @@ object NetworkUtils {
 
     /**
      * Get complete network information.
+     * If interfaceName is null, uses the first active non-loopback IPv4 interface.
      */
-    fun getNetworkInfo(context: Context): NetworkInfo? {
-        if (!isWifiConnected(context)) return null
-
-        val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-        @Suppress("DEPRECATION")
-        val wifiInfo = wifiManager.connectionInfo ?: return null
-        @Suppress("DEPRECATION")
-        val dhcpInfo = wifiManager.dhcpInfo
-
-        // Get IP address from DHCP info, fallback to NetworkInterface if 0 or null
-        var ipAddress = if (dhcpInfo != null && dhcpInfo.ipAddress != 0) {
-            intToIpAddress(dhcpInfo.ipAddress)
+    fun getNetworkInfo(context: Context, interfaceName: String? = null): NetworkInfo? {
+        val selectedInterface = if (interfaceName != null) {
+            getInterfaceByName(interfaceName)
         } else {
-            getLocalIpAddress() ?: return null
-        }
+            getAvailableInterfaces().firstOrNull()?.let { getInterfaceByName(it.name) }
+        } ?: return null
 
-        // Validate IP address is not 0.0.0.0
-        if (ipAddress == "0.0.0.0") {
-            ipAddress = getLocalIpAddress() ?: return null
-        }
+        val interfaceIpv4 = selectedInterface.inetAddresses.toList()
+            .filterIsInstance<Inet4Address>()
+            .firstOrNull { !it.isLoopbackAddress }
+            ?: return null
 
-        val subnetMask = if (dhcpInfo != null && dhcpInfo.netmask != 0) {
-            intToIpAddress(dhcpInfo.netmask)
-        } else {
-            "255.255.255.0" // Default to /24
-        }
+        val ipAddress = interfaceIpv4.hostAddress ?: return null
+        val prefixLength = selectedInterface.interfaceAddresses
+            .firstOrNull { it.address == interfaceIpv4 }
+            ?.networkPrefixLength
+            ?.toInt()
+            ?.coerceIn(0, 32)
+            ?: 24
+        val subnetMask = prefixLengthToSubnetMask(prefixLength)
 
-        val gateway = if (dhcpInfo != null && dhcpInfo.gateway != 0) {
-            intToIpAddress(dhcpInfo.gateway)
-        } else {
-            // Attempt to derive gateway from IP (common pattern: x.x.x.1)
-            val parts = ipAddress.split(".")
-            if (parts.size == 4) "${parts[0]}.${parts[1]}.${parts[2]}.1" else null
-        }
+        var ssid: String? = null
+        var bssid: String? = null
+        var frequency: Int? = null
+        var linkSpeed: Int? = null
+        var signalStrength: Int? = null
+        var gateway: String? = null
 
-        val networkPrefix = calculateNetworkPrefix(subnetMask)
+        // For Wi-Fi interfaces, enrich with DHCP and Wi-Fi details when available.
+        if (selectedInterface.name.equals("wlan0", ignoreCase = true) && isWifiConnected(context)) {
+            val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            @Suppress("DEPRECATION")
+            val wifiInfo = wifiManager.connectionInfo
+            @Suppress("DEPRECATION")
+            val dhcpInfo = wifiManager.dhcpInfo
+
+            ssid = getSSID(context)
+            bssid = wifiInfo?.bssid
+            frequency = wifiInfo?.frequency
+            linkSpeed = wifiInfo?.linkSpeed
+            signalStrength = wifiInfo?.rssi
+
+            gateway = if (dhcpInfo != null && dhcpInfo.gateway != 0) {
+                intToIpAddress(dhcpInfo.gateway)
+            } else {
+                val parts = ipAddress.split(".")
+                if (parts.size == 4) "${parts[0]}.${parts[1]}.${parts[2]}.1" else null
+            }
+        }
 
         return NetworkInfo(
-            ssid = getSSID(context),
-            bssid = wifiInfo.bssid,
+            interfaceName = selectedInterface.name,
+            ssid = ssid,
+            bssid = bssid,
             ipAddress = ipAddress,
             subnetMask = subnetMask,
             gateway = gateway,
-            networkPrefix = networkPrefix,
-            frequency = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) wifiInfo.frequency else null,
-            linkSpeed = wifiInfo.linkSpeed,
-            signalStrength = wifiInfo.rssi
+            networkPrefix = prefixLength,
+            frequency = frequency,
+            linkSpeed = linkSpeed,
+            signalStrength = signalStrength
         )
     }
 
@@ -121,32 +150,46 @@ object NetworkUtils {
     }
 
     /**
-     * Get device's IP address on the local network.
-     * Prefers the WiFi (wlan0) interface to avoid returning VPN or cellular IPs.
+     * Get active non-loopback IPv4 interfaces that can be scanned.
      */
-    fun getLocalIpAddress(): String? {
-        try {
-            val interfaces = NetworkInterface.getNetworkInterfaces()
+    fun getAvailableInterfaces(): List<NetworkInterfaceOption> {
+        return try {
+            val interfaces = NetworkInterface.getNetworkInterfaces().toList()
+            interfaces
+                .filter { isEligibleInterface(it) }
+                .mapNotNull { networkInterface ->
+                    val ipv4 = networkInterface.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .firstOrNull { !it.isLoopbackAddress }
+                        ?: return@mapNotNull null
 
-            // First pass: prefer wlan0 (WiFi interface)
-            var fallbackAddress: String? = null
-            while (interfaces.hasMoreElements()) {
-                val networkInterface = interfaces.nextElement()
-                val addresses = networkInterface.inetAddresses
-                while (addresses.hasMoreElements()) {
-                    val address = addresses.nextElement()
-                    if (!address.isLoopbackAddress && address is Inet4Address) {
-                        if (networkInterface.name.equals("wlan0", ignoreCase = true)) {
-                            return address.hostAddress
-                        }
-                        if (fallbackAddress == null) {
-                            fallbackAddress = address.hostAddress
-                        }
-                    }
+                    NetworkInterfaceOption(
+                        name = networkInterface.name,
+                        ipAddress = ipv4.hostAddress ?: return@mapNotNull null,
+                        type = inferInterfaceType(networkInterface.name)
+                    )
                 }
+                .sortedWith(compareBy<NetworkInterfaceOption> { interfaceTypePriority(it.type) }
+                    .thenBy { it.name })
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Get device's IP address on the selected local interface.
+     */
+    fun getLocalIpAddress(interfaceName: String? = null): String? {
+        try {
+            if (interfaceName != null) {
+                val networkInterface = getInterfaceByName(interfaceName) ?: return null
+                val address = networkInterface.inetAddresses.toList()
+                    .filterIsInstance<Inet4Address>()
+                    .firstOrNull { !it.isLoopbackAddress }
+                return address?.hostAddress
             }
 
-            return fallbackAddress
+            return getAvailableInterfaces().firstOrNull()?.ipAddress
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -154,22 +197,68 @@ object NetworkUtils {
     }
 
     /**
-     * Get local device's MAC address.
+     * Get local device's MAC address for the selected interface.
      */
-    fun getLocalMacAddress(): String? {
+    fun getLocalMacAddress(interfaceName: String? = null): String? {
         try {
-            val interfaces = NetworkInterface.getNetworkInterfaces()
-            while (interfaces.hasMoreElements()) {
-                val networkInterface = interfaces.nextElement()
-                if (networkInterface.name.equals("wlan0", ignoreCase = true)) {
-                    val mac = networkInterface.hardwareAddress ?: return null
-                    return mac.joinToString(":") { String.format("%02X", it) }
-                }
-            }
+            val networkInterface = if (interfaceName != null) {
+                getInterfaceByName(interfaceName)
+            } else {
+                getAvailableInterfaces().firstOrNull()?.let { getInterfaceByName(it.name) }
+            } ?: return null
+
+            val mac = networkInterface.hardwareAddress ?: return null
+            return mac.joinToString(":") { String.format("%02X", it) }
         } catch (e: Exception) {
             e.printStackTrace()
         }
         return null
+    }
+
+    private fun getInterfaceByName(interfaceName: String): NetworkInterface? {
+        return try {
+            NetworkInterface.getNetworkInterfaces().toList()
+                .firstOrNull { it.name.equals(interfaceName, ignoreCase = true) && isEligibleInterface(it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun isEligibleInterface(networkInterface: NetworkInterface): Boolean {
+        if (!networkInterface.isUp || networkInterface.isLoopback) return false
+        val hasIpv4 = networkInterface.inetAddresses.toList().any { address ->
+            address is Inet4Address && !address.isLoopbackAddress
+        }
+        return hasIpv4
+    }
+
+    private fun inferInterfaceType(interfaceName: String): InterfaceType {
+        val name = interfaceName.lowercase()
+        return when {
+            name.startsWith("wlan") || name.startsWith("wifi") -> InterfaceType.WIFI
+            name.startsWith("eth") || name.startsWith("en") -> InterfaceType.ETHERNET
+            name.startsWith("tun") || name.startsWith("tap") || name.startsWith("ppp") -> InterfaceType.VPN
+            name.startsWith("rmnet") || name.startsWith("ccmni") -> InterfaceType.CELLULAR
+            else -> InterfaceType.OTHER
+        }
+    }
+
+    private fun interfaceTypePriority(type: InterfaceType): Int {
+        return when (type) {
+            InterfaceType.WIFI -> 0
+            InterfaceType.ETHERNET -> 1
+            InterfaceType.VPN -> 2
+            InterfaceType.CELLULAR -> 3
+            else -> 4
+        }
+    }
+
+    private fun prefixLengthToSubnetMask(prefixLength: Int): String {
+        if (prefixLength <= 0) return "0.0.0.0"
+        if (prefixLength >= 32) return "255.255.255.255"
+
+        val mask = -1 shl (32 - prefixLength)
+        return "${(mask ushr 24) and 0xFF}.${(mask ushr 16) and 0xFF}.${(mask ushr 8) and 0xFF}.${mask and 0xFF}"
     }
 
     /**

--- a/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
+++ b/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
@@ -99,7 +99,7 @@ object NetworkUtils {
         var gateway: String? = null
 
         // For Wi-Fi interfaces, enrich with DHCP and Wi-Fi details when available.
-        if (selectedInterface.name.equals("wlan0", ignoreCase = true) && isWifiConnected(context)) {
+        if (inferInterfaceType(selectedInterface.name) == InterfaceType.WIFI && isWifiConnected(context)) {
             val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
             @Suppress("DEPRECATION")
             val wifiInfo = wifiManager.connectionInfo
@@ -226,6 +226,7 @@ object NetworkUtils {
 
     private fun isEligibleInterface(networkInterface: NetworkInterface): Boolean {
         if (!networkInterface.isUp || networkInterface.isLoopback) return false
+        if (inferInterfaceType(networkInterface.name) == InterfaceType.CELLULAR) return false
         val hasIpv4 = networkInterface.inetAddresses.toList().any { address ->
             address is Inet4Address && !address.isLoopbackAddress
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,15 @@
     <string name="no_devices_message">Make sure you\'re connected to a WiFi network and try scanning again.</string>
     <string name="no_wifi_title">No WiFi Connection</string>
     <string name="no_wifi_message">Connect to a WiFi network to scan for devices.</string>
+    <string name="no_active_interfaces">No active interface</string>
 
+    <!-- Interface Types -->
+    <string name="interface_type_wifi">Wi-Fi</string>
+    <string name="interface_type_ethernet">Ethernet</string>
+    <string name="interface_type_vpn">VPN</string>
+    <string name="interface_type_cellular">Cellular</string>
+    <string name="interface_type_network">Network</string>
+    
     <!-- Errors -->
     <string name="error_scan_failed">Scan failed: %s</string>
     <string name="error_permission_denied">Permission denied</string>
@@ -102,6 +110,7 @@
     <string name="confidence_percent">%d%% confidence</string>
     <string name="duration_seconds">%.1fs</string>
     <string name="action_retry">Retry</string>
+    <string name="interface_option_format">%1$s (%2$s) - %3$s</string>
 
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>
@@ -170,6 +179,7 @@
     <string name="cd_cancel_scan">Cancel current scan</string>
     <string name="cd_empty_state_icon">No devices illustration</string>
     <string name="cd_network_info">Network information</string>
+    <string name="cd_interface_selector">Select network interface</string>
     <string name="cd_port_status">Port %1$d is %2$s</string>
 
     <!-- Device list accessibility -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,8 @@
     <!-- Empty states -->
     <string name="no_devices_title">No Devices Found</string>
     <string name="no_devices_message">Make sure you\'re connected to a WiFi network and try scanning again.</string>
-    <string name="no_wifi_title">No WiFi Connection</string>
-    <string name="no_wifi_message">Connect to a WiFi network to scan for devices.</string>
+    <string name="no_wifi_title">No Network Connection</string>
+    <string name="no_wifi_message">No active network interfaces found. Connect to a network and try again.</string>
     <string name="no_active_interfaces">No active interface</string>
 
     <!-- Interface Types -->


### PR DESCRIPTION
- Add a dropdown menu to the NetworkInfoBar to select a active network interface
- Use different Icons and Names depending on the network type
WiFI <img width="24" height="24" alt="wifi_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/84b57833-9f07-41a2-a09a-fe8e16de2fa8" /> Ethernet <img width="24" height="24" alt="settings_ethernet_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/385df262-a982-4f55-aa58-1615c3f779cd" />  VPN <img width="24" height="24" alt="vpn_key_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/de92f34d-d864-415a-875a-a7a0e954747a" /> Cellular <img width="24" height="24" alt="signal_cellular_4_bar_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/5c1cbfab-64c6-4a8e-9280-23293ab1da12" /> Other <img width="24" height="24" alt="public_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz24" src="https://github.com/user-attachments/assets/fa640235-29fb-4ed0-baf0-86806b73ca3b" />
- Changes in the backend to accomodate the network scanning on a specific interface and not just on wlan0