### PR TITLE
Fix device list sort order

### DIFF
--- a/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
@@ -152,7 +152,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _devices.value = deviceList
 
         val sorted = deviceList.sortedWith(
-            compareBy({ !it.isCurrentDevice }, { !it.isOnline }, { it.ipAddress })
+           compareBy(
+              { !it.isCurrentDevice },
+              { !it.isOnline },
+              { it.ipAddress.split('.').fold(0L) { acc, part -> (acc shl 8) or part.toLong() } }
+           )
         )
 
         _onlineDevices.value = sorted.filter { it.isOnline }


### PR DESCRIPTION
Modified the sort comparison to handle the IP address correctly by converting the IP address string to a number.

Fixes #17 