### PR TITLE
Release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.3] - 2026-06-11
+
+### Fixed
+- Device list now sorts by IP address in correct numerical order (e.g. .2 before .10)
+
 ## [1.1.2] - 2026-05-20
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         applicationId = "com.networkscanner.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
-        versionName = "1.1.2"
+        versionCode = 8
+        versionName = "1.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,1 @@
+• Fixed device list sort order — IPs now sort numerically (e.g. .2 before .10)


### PR DESCRIPTION
### Fixed
- Device list now sorts by IP address in correct numerical order (e.g. .2 before .10)