### PR TITLE
refactor(i18n): derive language picker from locales_config

### DIFF
--- a/app/src/main/java/com/networkscanner/app/ui/screens/settings/LanguageDialog.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/screens/settings/LanguageDialog.kt
@@ -16,30 +16,57 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Column
+import android.content.Context
 import com.networkscanner.app.R
+import org.xmlpull.v1.XmlPullParser
+import java.util.Locale
+
+/** The "follow the device" option, which is not a real locale and is localized separately. */
+private const val SYSTEM = "system"
+
+private const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
 
 /**
- * Supported in-app languages, in display order. Endonyms (the name of a language
- * in that language) are intentionally not translated; only the "system" option
- * is localized.
+ * Locale tags selectable in-app, in display order: the special "system" option followed by
+ * the tags declared in res/xml/locales_config.xml — the single source of truth, shared with
+ * the OS per-app language screen. Parsed directly (rather than via the API 33+
+ * android.app.LocaleConfig) so it works down to minSdk 26.
  */
-private val LANGUAGE_CODES = listOf("system", "en", "ru", "es", "uk")
-
-@Composable
-private fun languageLabel(code: String): String = when (code) {
-    "system" -> stringResource(R.string.language_system_default)
-    "en" -> "English"
-    "ru" -> "Русский"
-    "es" -> "Español"
-    "uk" -> "Українська"
-    else -> code
+private fun languageCodes(context: Context): List<String> {
+    val codes = mutableListOf(SYSTEM)
+    context.resources.getXml(R.xml.locales_config).use { parser ->
+        var event = parser.eventType
+        while (event != XmlPullParser.END_DOCUMENT) {
+            if (event == XmlPullParser.START_TAG && parser.name == "locale") {
+                parser.getAttributeValue(ANDROID_NS, "name")?.let(codes::add)
+            }
+            event = parser.next()
+        }
+    }
+    return codes
 }
+
+/**
+ * Display label for a language code. "system" is localized; every real locale is shown as its
+ * own endonym (the language's name in that language, e.g. "Español"), derived from the tag and
+ * capitalized — never hardcoded, so adding a language needs no change here.
+ */
+@Composable
+private fun languageLabel(code: String): String =
+    if (code == SYSTEM) {
+        stringResource(R.string.language_system_default)
+    } else {
+        val locale = Locale.forLanguageTag(code)
+        locale.getDisplayName(locale).replaceFirstChar { it.titlecase(locale) }
+    }
 
 /** Display label for the currently-selected language, used for the settings row summary. */
 @Composable
@@ -55,6 +82,8 @@ fun LanguageDialog(
     onLanguageSelected: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val context = LocalContext.current
+    val languageCodes = remember(context) { languageCodes(context) }
     AlertDialog(
         onDismissRequest = onDismiss,
         icon = {
@@ -71,7 +100,7 @@ fun LanguageDialog(
                     .verticalScroll(rememberScrollState())
                     .selectableGroup()
             ) {
-                LANGUAGE_CODES.forEach { code ->
+                languageCodes.forEach { code ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/scripts/translation-status.sh
+++ b/scripts/translation-status.sh
@@ -13,7 +13,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_XML="$REPO_ROOT/app/src/main/res/values/strings.xml"
 README="$REPO_ROOT/README.md"
 
-# Locale code -> endonym; keep in sync with LanguageDialog.kt
+# Locale code -> endonym for the README table. The app derives endonyms at runtime via
+# Locale.getDisplayName (see LanguageDialog.kt); bash can't, so this map is maintained
+# independently. Add a case here when introducing a new values-<lang> locale.
 display_name() {
     case "$1" in
         en) echo "English"    ;;


### PR DESCRIPTION
The selectable-language list lived in three hand-synced places. Read the tags from res/xml/locales_config.xml at runtime and derive each endonym via Locale.getDisplayName, so adding a language no longer touches LanguageDialog.kt. Parsed directly (not LocaleConfig) to keep minSdk 26 support.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)
- [x] `./gradlew test` and `./gradlew lint` pass locally
- [x] UI changes include screenshots / screen recordings (if applicable)