### PR TITLE
chore(release): v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.1.5] - 2026-06-29
+
+### Added
+- Spanish (es) translation (#30)
+- Ukrainian (uk) translation (#29, #37, #40)
+- Arabic (ar) translation (#35, #38)
+- Simplified Chinese (zh) translation (#41)
+
+### Improved
+- Language picker now derived from locales_config, so newly added locales appear automatically (#33)
+
+### Changed
+- Split PR conventions workflow into separate title and labeler files (#32)
+- Bumped actions/setup-java from 5.3.0 to 5.4.0 (#39)
+- Polished README with badges and a translation status table (#28, #31)
+
 ## [1.1.4] - 2026-06-20
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         applicationId = "com.networkscanner.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.1.4"
+        versionCode = 10
+        versionName = "1.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,2 @@
+• New translations: Spanish, Ukrainian, Arabic, and Simplified Chinese
+• Language picker now updates automatically as locales are added


### PR DESCRIPTION
### Release PRs only

- [x] `versionCode` bumped by exactly 1 **and** `versionName` updated in `app/build.gradle.kts`
- [x] Branch is named `release/v<versionName>`
- [x] `CHANGELOG.md` has a `## [<versionName>]` entry
- [x] `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` added (F-Droid / Play "What's New")
