### PR TITLE
fix(scanner): device identification accuracy and reliable scan cancellation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Bundle native debug symbols into the AAB so Play can symbolicate
+            // native crashes/ANRs (fixes the "no debug symbols uploaded" warning).
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             if (releaseStoreFile != null && releaseStorePassword != null && releaseKeyAlias != null && releaseKeyPassword != null) {
                 signingConfig = signingConfigs.getByName("release")
             }

--- a/app/src/main/java/com/networkscanner/app/data/DeviceType.kt
+++ b/app/src/main/java/com/networkscanner/app/data/DeviceType.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.Tablet
 import androidx.compose.material.icons.outlined.Tv
 import androidx.compose.material.icons.outlined.Watch
 import androidx.compose.ui.graphics.vector.ImageVector
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Enumeration of device types with associated icons and display names.
@@ -43,7 +44,10 @@ enum class DeviceType(
     LAPTOP(
         displayName = "Laptop",
         icon = Icons.Outlined.Laptop,
-        keywords = listOf("macbook", "laptop", "notebook", "thinkpad", "dell", "hp", "lenovo", "acer", "asus", "msi", "surface", "chromebook", "intel", "realtek")
+        // Note: NIC-vendor names (intel, realtek) and the too-generic "hp" are
+        // deliberately excluded — they appear on desktops, servers and printers
+        // just as often as laptops and caused systematic misclassification.
+        keywords = listOf("macbook", "laptop", "notebook", "thinkpad", "dell", "lenovo", "acer", "asus", "msi", "surface", "chromebook")
     ),
     DESKTOP(
         displayName = "Desktop",
@@ -97,62 +101,86 @@ enum class DeviceType(
     );
 
     companion object {
+        // Compiled word-boundary matchers, cached per keyword. Matching on word
+        // boundaries (rather than raw substrings) prevents short keywords like
+        // "hp"/"pc"/"tv" from hitting inside unrelated words (e.g. "sharp").
+        private val keywordRegexCache = ConcurrentHashMap<String, Regex>()
+
+        private fun wordMatch(text: String, keyword: String): Boolean {
+            val regex = keywordRegexCache.getOrPut(keyword) {
+                Regex("\\b" + Regex.escape(keyword) + "\\b")
+            }
+            return regex.containsMatchIn(text)
+        }
+
         /**
-         * Identify device type based on hostname, vendor, or mDNS service type.
+         * Map a single mDNS service type to a device type, or null if the service
+         * doesn't identify one on its own.
+         *
+         * Note: _googlecast is intentionally omitted — it's advertised by both
+         * dedicated Chromecasts (TV) and Android phones running Google Home.
+         * probePortHeuristics() disambiguates using ports 8008/8009.
+         */
+        private fun classifyMdns(service: String): DeviceType? {
+            val s = service.lowercase()
+            return when {
+                s.contains("_airplay") -> TV
+                s.contains("_androidtvremote2") -> TV
+                s.contains("_raop") || s.contains("_spotify-connect") -> SMART_SPEAKER
+                s.contains("_homekit") || s.contains("_matter") -> SMART_HOME
+                s.contains("_printer") || s.contains("_ipp") || s.contains("_pdl") -> PRINTER
+                s.contains("_smb") || s.contains("_afpovertcp") -> NAS
+                s.contains("_ssh") || s.contains("_sftp") -> SERVER
+                else -> null
+            }
+        }
+
+        /** Map an SSDP/UPnP device type URN to a device type, or null. */
+        private fun classifySsdp(ssdpDeviceType: String?): DeviceType? {
+            val s = ssdpDeviceType ?: return null
+            return when {
+                s.contains("MediaRenderer") -> TV
+                s.contains("MediaServer") -> NAS
+                s.contains("InternetGatewayDevice") || s.contains("WANDevice") ||
+                    s.contains("WANConnectionDevice") -> ROUTER
+                s.contains("Printer") -> PRINTER
+                else -> null
+            }
+        }
+
+        /**
+         * Identify device type from the available signals.
+         *
+         * Specific, reliable signals (mDNS service types, then SSDP device type)
+         * are checked first so they aren't shadowed by generic hostname/vendor
+         * keywords. Only if those are inconclusive do we fall back to scoring
+         * hostname/vendor keywords, picking the type with the most matches.
          */
         fun identify(
             hostname: String? = null,
             vendor: String? = null,
-            mdnsServiceType: String? = null,
+            mdnsServices: List<String> = emptyList(),
             ssdpDeviceType: String? = null
         ): DeviceType {
-            val searchTerms = listOfNotNull(
-                hostname?.lowercase(),
-                vendor?.lowercase(),
-                mdnsServiceType?.lowercase(),
-                ssdpDeviceType?.lowercase()
-            ).joinToString(" ")
-
-            if (searchTerms.isEmpty()) return UNKNOWN
-
-            // Check each device type's keywords
-            for (type in entries) {
-                if (type == UNKNOWN) continue
-                for (keyword in type.keywords) {
-                    if (searchTerms.contains(keyword)) {
-                        return type
-                    }
-                }
+            // 1) mDNS service types — most reliable identity signal.
+            for (service in mdnsServices) {
+                classifyMdns(service)?.let { return it }
             }
 
-            // Special cases based on mDNS service types
-            // Note: _googlecast is intentionally omitted — it's advertised by both
-            // dedicated Chromecasts (TV) and Android phones running Google Home.
-            // probePortHeuristics() disambiguates using port 8008/8009.
-            mdnsServiceType?.let {
-                return when {
-                    it.contains("_airplay") -> TV
-                    it.contains("_raop") -> SMART_SPEAKER
-                    it.contains("_androidtvremote2") -> TV
-                    it.contains("_printer") || it.contains("_ipp") -> PRINTER
-                    it.contains("_smb") || it.contains("_afpovertcp") -> NAS
-                    it.contains("_ssh") || it.contains("_sftp") -> SERVER
-                    else -> UNKNOWN
-                }
-            }
+            // 2) SSDP/UPnP device type.
+            classifySsdp(ssdpDeviceType)?.let { return it }
 
-            // SSDP device type detection
-            ssdpDeviceType?.let {
-                return when {
-                    it.contains("MediaRenderer") -> TV
-                    it.contains("MediaServer") -> NAS
-                    it.contains("InternetGatewayDevice") -> ROUTER
-                    it.contains("Printer") -> PRINTER
-                    else -> UNKNOWN
-                }
-            }
+            // 3) Keyword scoring over hostname + vendor.
+            val text = listOfNotNull(hostname, vendor).joinToString(" ").lowercase()
+            if (text.isBlank()) return UNKNOWN
 
-            return UNKNOWN
+            val best = entries
+                .filter { it != UNKNOWN }
+                .map { type -> type to type.keywords.count { kw -> wordMatch(text, kw) } }
+                .filter { (_, score) -> score > 0 }
+                .maxByOrNull { (_, score) -> score }
+
+            return best?.first ?: UNKNOWN
         }
     }
 }

--- a/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
+++ b/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
@@ -166,7 +166,7 @@ class NetworkScanner(private val context: Context) {
             deviceCache.putAll(discoveredDevices)
 
             val deviceList = discoveredDevices.values.toList()
-                .sortedWith(compareBy({ !it.isCurrentDevice }, { it.ipAddress }))
+                .sortedWith(compareBy({ !it.isCurrentDevice }, { ipSortKey(it.ipAddress) }))
 
             _devices.value = deviceList
 
@@ -385,8 +385,10 @@ class NetworkScanner(private val context: Context) {
                 val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
                 val banner = StringBuilder()
 
-                // For HTTP ports, send a request to trigger response
-                if (port in listOf(80, 8080, 8000, 8008, 8081, 8888, 443, 8443)) {
+                // For plaintext HTTP ports, send a request to trigger a response.
+                // TLS ports (443/8443) are excluded: they expect a TLS handshake,
+                // not cleartext HTTP, so a plaintext request never yields a banner.
+                if (port in listOf(80, 8080, 8000, 8008, 8081, 8888)) {
                     socket.getOutputStream().write("HEAD / HTTP/1.0\r\n\r\n".toByteArray())
                 } else {
                     // For non-HTTP ports, try reading first — many services
@@ -433,10 +435,11 @@ class NetworkScanner(private val context: Context) {
     private fun extractVersion(banner: String?): String? {
         if (banner == null) return null
 
-        // Common version patterns
+        // Common version patterns. Specific server/software signatures are
+        // listed before the generic "Server:" header so we extract the precise
+        // version (e.g. "2.4.1") rather than the whole header value.
         val patterns = listOf(
             Regex("""SSH-[\d.]+-([\w\d._-]+)"""),
-            Regex("""Server:\s*([^\r\n]+)""", RegexOption.IGNORE_CASE),
             Regex("""Apache/([\d.]+)"""),
             Regex("""nginx/([\d.]+)"""),
             Regex("""OpenSSH_([\d.p]+)"""),
@@ -445,7 +448,8 @@ class NetworkScanner(private val context: Context) {
             Regex("""Microsoft-IIS/([\d.]+)"""),
             Regex("""vsftpd\s+([\d.]+)"""),
             Regex("""ProFTPD\s+([\d.]+)"""),
-            Regex("""Dropbear\s+([\d.]+)""")
+            Regex("""Dropbear\s+([\d.]+)"""),
+            Regex("""Server:\s*([^\r\n]+)""", RegexOption.IGNORE_CASE)
         )
 
         for (pattern in patterns) {
@@ -584,13 +588,15 @@ class NetworkScanner(private val context: Context) {
     }
 
     private fun detectWindowsVersion(banners: String): String {
+        // Check the most specific labels first. The old "10.0" catch-all was
+        // dropped — it matched unrelated version strings and mislabeled servers.
         return when {
-            banners.contains("windows 11") || banners.contains("10.0") -> "Windows 11/10"
-            banners.contains("windows 10") -> "Windows 10"
             banners.contains("windows server 2022") -> "Windows Server 2022"
             banners.contains("windows server 2019") -> "Windows Server 2019"
             banners.contains("windows server 2016") -> "Windows Server 2016"
             banners.contains("windows server") -> "Windows Server"
+            banners.contains("windows 11") -> "Windows 11"
+            banners.contains("windows 10") -> "Windows 10"
             else -> "Windows"
         }
     }
@@ -806,7 +812,7 @@ class NetworkScanner(private val context: Context) {
                     val deviceType = DeviceType.identify(
                         hostname = device.hostname,
                         vendor = vendor,
-                        mdnsServiceType = device.mdnsServices.firstOrNull(),
+                        mdnsServices = device.mdnsServices,
                         ssdpDeviceType = device.ssdpInfo?.deviceType
                     )
 
@@ -945,42 +951,48 @@ class NetworkScanner(private val context: Context) {
                         }
                     }
 
-                    ip?.let {
-                        val existing = discoveredDevices[it]
-                        val services = (existing?.mdnsServices ?: emptyList()) + (serviceInfo?.serviceType ?: "")
+                    ip?.let { resolvedIp ->
                         val hostname = serviceInfo?.serviceName
                             ?.takeIf { name -> name.isNotBlank() }
-                            ?.let { sanitizeMdnsName(it) }
+                            ?.let { name -> sanitizeMdnsName(name) }
+                        val newService = serviceInfo?.serviceType ?: ""
 
-                        // Identify device type immediately so UI shows correct icon
-                        val identifiedType = DeviceType.identify(
-                            hostname = hostname ?: existing?.hostname,
-                            vendor = existing?.vendor,
-                            mdnsServiceType = services.firstOrNull(),
-                            ssdpDeviceType = existing?.ssdpInfo?.deviceType
-                        )
-                        val deviceType = when {
-                            existing?.isCurrentDevice == true -> DeviceType.SMARTPHONE
-                            existing != null && existing.deviceType != DeviceType.UNKNOWN -> existing.deviceType
-                            identifiedType != DeviceType.UNKNOWN -> identifiedType
-                            else -> existing?.deviceType ?: DeviceType.UNKNOWN
+                        // mDNS resolve callbacks fire on NsdManager threads and can
+                        // run concurrently for the SAME IP (a device advertising
+                        // multiple service types). A get-then-put would let one
+                        // callback clobber another's services, so merge atomically.
+                        discoveredDevices.compute(resolvedIp) { _, existing ->
+                            val services = ((existing?.mdnsServices ?: emptyList()) + newService).distinct()
+
+                            // Identify device type immediately so UI shows correct icon
+                            val identifiedType = DeviceType.identify(
+                                hostname = hostname ?: existing?.hostname,
+                                vendor = existing?.vendor,
+                                mdnsServices = services,
+                                ssdpDeviceType = existing?.ssdpInfo?.deviceType
+                            )
+                            val deviceType = when {
+                                existing?.isCurrentDevice == true -> DeviceType.SMARTPHONE
+                                existing != null && existing.deviceType != DeviceType.UNKNOWN -> existing.deviceType
+                                identifiedType != DeviceType.UNKNOWN -> identifiedType
+                                else -> existing?.deviceType ?: DeviceType.UNKNOWN
+                            }
+
+                            existing?.copy(
+                                hostname = existing.hostname ?: hostname,
+                                mdnsServices = services,
+                                deviceType = deviceType,
+                                discoveredVia = if (existing.discoveredVia == DiscoveryMethod.MANUAL)
+                                    existing.discoveredVia else DiscoveryMethod.MDNS
+                            ) ?: Device(
+                                ipAddress = resolvedIp,
+                                hostname = hostname,
+                                mdnsServices = services,
+                                deviceType = identifiedType,
+                                isOnline = true,
+                                discoveredVia = DiscoveryMethod.MDNS
+                            )
                         }
-
-                        val device = existing?.copy(
-                            hostname = existing.hostname ?: hostname,
-                            mdnsServices = services.distinct(),
-                            deviceType = deviceType,
-                            discoveredVia = if (existing.discoveredVia == DiscoveryMethod.MANUAL)
-                                existing.discoveredVia else DiscoveryMethod.MDNS
-                        ) ?: Device(
-                            ipAddress = it,
-                            hostname = hostname,
-                            mdnsServices = services,
-                            deviceType = identifiedType,
-                            isOnline = true,
-                            discoveredVia = DiscoveryMethod.MDNS
-                        )
-                        discoveredDevices[it] = device
                         updateDeviceCount()
                     }
                 } finally {
@@ -1125,7 +1137,7 @@ class NetworkScanner(private val context: Context) {
         val identifiedType = DeviceType.identify(
             hostname = existing?.hostname,
             vendor = existing?.vendor,
-            mdnsServiceType = existing?.mdnsServices?.firstOrNull(),
+            mdnsServices = existing?.mdnsServices ?: emptyList(),
             ssdpDeviceType = st
         )
         val deviceType = when {
@@ -1355,7 +1367,7 @@ class NetworkScanner(private val context: Context) {
             val deviceType = DeviceType.identify(
                 hostname = hostname,
                 vendor = updatedDevice.vendor,
-                mdnsServiceType = updatedDevice.mdnsServices.firstOrNull(),
+                mdnsServices = updatedDevice.mdnsServices,
                 ssdpDeviceType = updatedDevice.ssdpInfo?.deviceType
             )
 
@@ -1471,6 +1483,23 @@ class NetworkScanner(private val context: Context) {
     private fun sanitizeMdnsName(name: String): String {
         val stripped = name.replace(Regex("-[0-9a-fA-F]{8,}$"), "")
         return stripped.replace('-', ' ').trim()
+    }
+
+    /**
+     * Build a numerically-orderable key for an IPv4 address so devices sort as
+     * .2 < .10 < .100 instead of lexicographically (.10 < .2). Non-IPv4 or
+     * malformed addresses sort last.
+     */
+    private fun ipSortKey(ip: String): Long {
+        val parts = ip.split(".")
+        if (parts.size != 4) return Long.MAX_VALUE
+        var key = 0L
+        for (part in parts) {
+            val octet = part.toIntOrNull() ?: return Long.MAX_VALUE
+            if (octet !in 0..255) return Long.MAX_VALUE
+            key = (key shl 8) or octet.toLong()
+        }
+        return key
     }
 
     private fun updateProgress(

--- a/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
+++ b/app/src/main/java/com/networkscanner/app/network/NetworkScanner.kt
@@ -177,6 +177,10 @@ class NetworkScanner(private val context: Context) {
                 networkInfo = networkInfo,
                 scanStatus = ScanStatus.COMPLETED
             )
+        } catch (e: CancellationException) {
+            // User cancelled the scan — propagate cleanly rather than reporting
+            // it as an ERROR result (the multicast lock is freed in finally).
+            throw e
         } catch (e: Exception) {
             ScanResult(
                 devices = discoveredDevices.values.toList(),
@@ -200,7 +204,7 @@ class NetworkScanner(private val context: Context) {
         ports: List<Int> = CommonPorts.TOP_PORTS,
         customServiceNames: Map<Int, String> = emptyMap(),
         fullScan: Boolean = false
-    ): DeepScanResult = withContext(scope.coroutineContext) {
+    ): DeepScanResult = withContext(Dispatchers.IO) {
         val portThreads = if (fullScan) FULL_SCAN_PORT_THREADS else PORT_THREADS
         val portTimeoutMs = if (fullScan) FULL_SCAN_PORT_TIMEOUT_MS else PORT_TIMEOUT_MS
         val startTime = System.currentTimeMillis()

--- a/app/src/main/java/com/networkscanner/app/ui/DeviceDetailViewModel.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/DeviceDetailViewModel.kt
@@ -84,6 +84,9 @@ class DeviceDetailViewModel(application: Application) : AndroidViewModel(applica
     fun startDeepScan(fullScan: Boolean = false) {
         val currentDevice = _device.value ?: return
 
+        // Cancelling deepScanJob structurally cancels the in-flight performDeepScan
+        // (it runs under this job), so a previous scan can't keep running and
+        // fighting the new one over the shared deepScanProgress flow.
         deepScanJob?.cancel()
         progressJob?.cancel()
 
@@ -144,9 +147,11 @@ class DeviceDetailViewModel(application: Application) : AndroidViewModel(applica
     }
 
     fun cancelDeepScan() {
+        // deepScanJob owns the in-flight performDeepScan, so cancelling it stops
+        // the scan. We deliberately don't call scanner.cancel() here — that job is
+        // shared with the main network scan and would abort it too.
         deepScanJob?.cancel()
         progressJob?.cancel()
-        scanner.cancel()
         _deepScanState.value = DeepScanState.Idle
     }
 

--- a/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/networkscanner/app/ui/MainViewModel.kt
@@ -8,6 +8,7 @@ import com.networkscanner.app.data.*
 import com.networkscanner.app.data.repository.DeviceCustomizationRepository
 import com.networkscanner.app.util.NetworkInterfaceOption
 import com.networkscanner.app.util.NetworkUtils
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -148,6 +149,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         _uiState.value = UiState.Idle
                     }
                 }
+            } catch (e: CancellationException) {
+                // Cancelled by the user via cancelScan(), which already reset the
+                // UI to Idle. Don't surface it as an error; rethrow to honor
+                // structured concurrency.
+                throw e
             } catch (e: Exception) {
                 _uiState.value = UiState.Error(e.message ?: "Scan failed")
                 _errorMessage.trySend(e.message ?: "Scan failed")


### PR DESCRIPTION
## Device identification
- Check mDNS/SSDP signals before generic keywords, so Android/Samsung TVs
  and UPnP MediaServers stop misclassifying as phones/servers.
- Match keywords on word boundaries + by score (not first substring hit);
  drop NIC-vendor keywords (intel/realtek) and generic "hp" from LAPTOP.

## Scanner
- Merge concurrent mDNS resolve callbacks atomically (fixes a lost-update race).
- More accurate Windows/banner version detection, skip cleartext probes on
  TLS ports, and sort devices by numeric IPv4 order.

## Cancellation
- Cancelling a scan returns cleanly to idle instead of showing an error.
- Deep scan runs under the caller's coroutine: cancellation is structural,
  fixes a re-scan leak, and stays isolated from the main scan.

## Build
- Bundle native debug symbols in the release AAB for Play symbolication.

`./gradlew compileDebugKotlin` passes.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)
- [x] `./gradlew test` and `./gradlew lint` pass locally