### PR TITLE
fix(scanner): scan full subnet range instead of assuming /24

### DIFF
--- a/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
+++ b/app/src/main/java/com/networkscanner/app/util/NetworkUtils.kt
@@ -263,36 +263,72 @@ object NetworkUtils {
     }
 
     /**
-     * Generate list of IP addresses in the subnet to scan.
-     * Respects the actual subnet size instead of always scanning /24.
+     * Largest subnet, measured in usable host addresses, that a scan will sweep
+     * in full automatically. A /22 (1022 hosts) fits within this cap; anything
+     * wider (/21 and up) falls back to the device's local /24, because sweeping
+     * tens of thousands to millions of addresses is infeasible on a phone.
+     *
+     * NOTE: letting the user opt into scanning a larger range (whole subnet or a
+     * custom range) on wide networks is planned separately — see
+     * docs/large-subnet-handling.md.
+     */
+    const val MAX_SCAN_HOSTS = 1024
+
+    /**
+     * Generate the list of IP addresses to ping-sweep, based on the interface's
+     * actual network prefix rather than assuming a /24.
+     *
+     * - Subnets with up to [MAX_SCAN_HOSTS] usable hosts (through /22) are swept
+     *   in full, so /23 and /22 networks are covered — including the gateway,
+     *   which may sit in a different /24 than the device.
+     * - Wider subnets (/21 and up, e.g. a public-Wi-Fi /8) fall back to the /24
+     *   the device is in, to keep the sweep feasible.
      */
     fun getIpRange(networkInfo: NetworkInfo): List<String> {
-        val baseIp = networkInfo.networkAddress
-        val parts = baseIp.split(".")
-        if (parts.size != 4) return emptyList()
+        val prefix = networkInfo.networkPrefix.coerceIn(0, 32)
 
-        val prefix = networkInfo.networkPrefix
+        // /31 (point-to-point) and /32 (single host) have no conventional host range.
+        if (prefix >= 31) return listOf(networkInfo.ipAddress)
 
-        // For /24 or smaller subnets, scan the exact range
-        if (prefix >= 24) {
-            val ipPrefix = parts.take(3).joinToString(".")
-            val hostBits = 32 - prefix
-            val numHosts = (1 shl hostBits) - 2 // Exclude network and broadcast
-            val startHost = 1
-            val endHost = startHost + numHosts - 1
+        val deviceInt = ipv4ToLong(networkInfo.ipAddress)
+        val networkInt = ipv4ToLong(networkInfo.networkAddress) ?: deviceInt ?: return emptyList()
 
-            return (startHost..endHost).map { "$ipPrefix.$it" }
+        val totalAddresses = 1L shl (32 - prefix)
+        // Usable host range excludes the network address and the broadcast address.
+        val firstHost = networkInt + 1
+        val lastHost = networkInt + totalAddresses - 2
+        val totalHosts = lastHost - firstHost + 1
+
+        if (totalHosts <= MAX_SCAN_HOSTS) {
+            return (firstHost..lastHost).map { longToIpv4(it) }
         }
 
-        // For larger subnets (< /24), scan the /24 segment the device is actually in
-        val deviceParts = networkInfo.ipAddress.split(".")
-        val localPrefix = if (deviceParts.size == 4) {
-            deviceParts.take(3).joinToString(".")
-        } else {
-            parts.take(3).joinToString(".")
-        }
-        return (1..254).map { "$localPrefix.$it" }
+        // Subnet too large to sweep in full — scan the /24 the device sits in.
+        val base = (deviceInt ?: networkInt) and 0xFFFFFF00L
+        return (1L..254L).map { longToIpv4(base + it) }
     }
+
+    /**
+     * Convert a dotted-quad IPv4 string to its big-endian numeric value
+     * (0..2^32-1), or null if malformed. Unlike [ipAddressToInt] this preserves
+     * octet order, so the result is safe to use for range arithmetic.
+     */
+    private fun ipv4ToLong(ip: String): Long? {
+        val parts = ip.split(".")
+        if (parts.size != 4) return null
+        var result = 0L
+        for (part in parts) {
+            val octet = part.toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            result = (result shl 8) or octet.toLong()
+        }
+        return result
+    }
+
+    /** Convert a big-endian numeric IPv4 value back to dotted-quad form. */
+    private fun longToIpv4(value: Long): String =
+        "${(value ushr 24) and 0xFF}.${(value ushr 16) and 0xFF}." +
+            "${(value ushr 8) and 0xFF}.${value and 0xFF}"
 
     /**
      * Convert integer IP address to string format.

--- a/app/src/test/java/com/networkscanner/app/util/NetworkUtilsGetIpRangeTest.kt
+++ b/app/src/test/java/com/networkscanner/app/util/NetworkUtilsGetIpRangeTest.kt
@@ -1,0 +1,119 @@
+package com.networkscanner.app.util
+
+import com.networkscanner.app.data.NetworkInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [NetworkUtils.getIpRange].
+ *
+ * Regression coverage for issue #18: subnets smaller than /24 (e.g. /23) were
+ * collapsed to the device's own /24, so hosts — including a gateway in the
+ * sibling /24 — were never scanned.
+ */
+class NetworkUtilsGetIpRangeTest {
+
+    /** Build a NetworkInfo with a subnet mask derived from the prefix. */
+    private fun netInfo(ip: String, prefix: Int): NetworkInfo = NetworkInfo(
+        interfaceName = "wlan0",
+        ssid = null,
+        bssid = null,
+        ipAddress = ip,
+        subnetMask = maskFor(prefix),
+        gateway = null,
+        networkPrefix = prefix
+    )
+
+    private fun maskFor(prefix: Int): String {
+        if (prefix <= 0) return "0.0.0.0"
+        if (prefix >= 32) return "255.255.255.255"
+        val mask = -1 shl (32 - prefix)
+        return "${(mask ushr 24) and 0xFF}.${(mask ushr 16) and 0xFF}." +
+            "${(mask ushr 8) and 0xFF}.${mask and 0xFF}"
+    }
+
+    @Test
+    fun slash24_scansFullSingleSubnet() {
+        val range = NetworkUtils.getIpRange(netInfo("192.168.1.50", 24))
+        assertEquals(254, range.size)
+        assertEquals("192.168.1.1", range.first())
+        assertEquals("192.168.1.254", range.last())
+    }
+
+    @Test
+    fun slash23_scansBothHalvesIncludingSiblingSubnet() {
+        // The reporter's core case: device in the upper /24, gateway in the lower.
+        val range = NetworkUtils.getIpRange(netInfo("10.0.1.50", 23))
+        assertEquals(510, range.size)
+        assertEquals("10.0.0.1", range.first())
+        assertEquals("10.0.1.254", range.last())
+        // A gateway at 10.0.0.1 (sibling /24) must be covered — this regressed before.
+        assertTrue("10.0.0.1" in range)
+        assertTrue("10.0.1.1" in range)
+    }
+
+    @Test
+    fun slash22_atCap_scansFull() {
+        val range = NetworkUtils.getIpRange(netInfo("172.16.5.10", 22))
+        assertEquals(1022, range.size)
+        assertEquals("172.16.4.1", range.first())
+        assertEquals("172.16.7.254", range.last())
+    }
+
+    @Test
+    fun slash21_overCap_fallsBackToDeviceLocalSlash24() {
+        val range = NetworkUtils.getIpRange(netInfo("172.16.20.5", 21))
+        assertEquals(254, range.size)
+        assertEquals("172.16.20.1", range.first())
+        assertEquals("172.16.20.254", range.last())
+    }
+
+    @Test
+    fun slash8_fallsBackToDeviceLocalSlash24_notMillions() {
+        val range = NetworkUtils.getIpRange(netInfo("10.5.3.20", 8))
+        assertEquals(254, range.size)
+        assertEquals("10.5.3.1", range.first())
+        assertEquals("10.5.3.254", range.last())
+        // Must NOT attempt to materialize the full /8.
+        assertTrue(range.size <= NetworkUtils.MAX_SCAN_HOSTS)
+    }
+
+    @Test
+    fun slash30_scansTwoUsableHosts() {
+        val range = NetworkUtils.getIpRange(netInfo("192.168.1.5", 30))
+        assertEquals(2, range.size)
+        assertEquals("192.168.1.5", range.first())
+        assertEquals("192.168.1.6", range.last())
+    }
+
+    @Test
+    fun slash32_scansOnlyTheHost() {
+        val range = NetworkUtils.getIpRange(netInfo("192.168.1.5", 32))
+        assertEquals(listOf("192.168.1.5"), range)
+    }
+
+    @Test
+    fun slash31_scansOnlyTheHost() {
+        val range = NetworkUtils.getIpRange(netInfo("192.168.1.4", 31))
+        assertEquals(listOf("192.168.1.4"), range)
+    }
+
+    @Test
+    fun neverExceedsScanCap() {
+        for (prefix in 8..30) {
+            val size = NetworkUtils.getIpRange(netInfo("10.20.30.40", prefix)).size
+            assertTrue(
+                "prefix /$prefix produced $size addresses",
+                size <= NetworkUtils.MAX_SCAN_HOSTS
+            )
+        }
+    }
+
+    @Test
+    fun malformedIp_returnsEmptyGracefully() {
+        // A malformed interface address can't be scanned — return empty, don't crash.
+        val range = NetworkUtils.getIpRange(netInfo("not.an.ip", 24))
+        assertTrue(range.isEmpty())
+    }
+}


### PR DESCRIPTION
getIpRange() collapsed any subnet smaller than /24 to the device's own /24, so hosts in a sibling /24 — often the gateway — were never scanned. Compute the real host range from the network prefix and sweep it in full up to MAX_SCAN_HOSTS (1024, through /22); wider subnets fall back to the local /24 to stay feasible on a phone.

Fixes #18 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org)
- [ ] `./gradlew test` and `./gradlew lint` pass locally
- [ ] UI changes include screenshots / screen recordings (if applicable)
